### PR TITLE
Update Ruby Version in GitHub Actions Workflow to 3.2.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0.2'
+        ruby-version: '3.2.2'
     - name: Install deps
       run: |
         gem install bundler

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+psolsson.m3hrdadfi.me

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-psolsson.m3hrdadfi.me


### PR DESCRIPTION
This pull request updates the Ruby version used in the GitHub Actions workflow from 3.0.2 to 3.2.2.

_Compatibility: The update ensures compatibility with gems that require a newer version of Ruby._