### PR TITLE
SEO + LLM visibility: schema graph, OG/Twitter, robots, sitemap, FAQ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :jekyll_plugins do
     gem 'jekyll-github-metadata'
     gem 'jekyll-paginate-v2'
     gem 'jekyll-scholar'
+    gem 'jekyll-sitemap'
     gem 'jekyll-twitter-plugin'
     gem 'jemoji'
     gem 'unicode_utils'

--- a/_config.yml
+++ b/_config.yml
@@ -2,21 +2,21 @@
 # Site settings
 # -----------------------------------------------------------------------------
 
-title: AI and Machine Learning in the Natural Sciences # the website title (if blank, full name will be used instead)
+title: AIMLeNS — AI and Machine Learning in the Natural Sciences # the website title (if blank, full name will be used instead)
 first_name: Simon
 middle_name: 
 last_name: Olsson
 email: simonols@chalmers.se
 description:  
-  Research group at Chalmers University developing machine learning models to accelerate molecular simulations, molecular dynamics, vaccine design, drug design and materials design. Lead by Simon Olsson, pioneer in AI for Molecular Simulation.
+  AIMLeNS is the AI and Machine Learning in the Natural Sciences research group at Chalmers University of Technology, Gothenburg, led by Associate Professor Simon Olsson. We develop machine learning methods for molecular simulation, generative AI for drug, antibody and vaccine design, and AI-driven inverse molecular design.
 footer_text: >
-  AI4Science, AI for Science, AI for Molecular Simulation, AI for Molecular Design, AI for Drug-Design, AI for Materials
+  AIMLeNS is the AI and Machine Learning in the Natural Sciences research group at Chalmers University of Technology, led by Simon Olsson.
  
 
 icon: + # the emoji used as the favicon
-url:  # the base hostname & protocol for your site
+url: https://psolsson.github.io # the base hostname & protocol for your site
 baseurl: / # the subpath of your site, e.g. /blog/
-last_updated: false # set to true if you want to display last updated in the footer
+last_updated: true # set to true if you want to display last updated in the footer
 impressum_path:  # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
 
 # -----------------------------------------------------------------------------
@@ -35,8 +35,8 @@ max_width: 800px
 # Open Graph
 # -----------------------------------------------------------------------------
 # Display links to the page with a preview object on social media.
-serve_og_meta: false # Include Open Graph meta tags in the HTML head
-og_image: # The site-wide (default for all links) Open Graph preview image
+serve_og_meta: true # Include Open Graph meta tags in the HTML head
+og_image: /assets/img/group2025.jpg # The site-wide (default for all links) Open Graph preview image
 
 # -----------------------------------------------------------------------------
 # Social integration
@@ -133,6 +133,7 @@ plugins:
   - jekyll-email-protect
   - jekyll-github-metadata
   - jekyll-paginate-v2
+  - jekyll-sitemap
   - jekyll/scholar
 #  - jekyll-twitter-plugin
 #  - jemoji

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,37 +5,91 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "Person",
-  "name": "Simon Olsson",
-  "givenName": "Simon",
-  "familyName": "Olsson",
-  "jobTitle": "Associate Professor",
-  "url": "https://psolsson.github.io",
-  "affiliation": {
-    "@type": "Organization",
-    "name": "Chalmers University of Technology",
-    "url": "https://www.chalmers.se"
-  },
-  "worksFor": {
-    "@type": "Organization",
-    "name": "AIMLeNS - AI and Machine Learning in the Natural Sciences",
-    "url": "https://psolsson.github.io"
-  },
-  "knowsAbout": [
-    "Machine Learning for Molecular Simulation",
-    "Generative AI for Drug Design",
-    "Boltzmann Generators",
-    "Implicit Transfer Operators",
-    "Generative Molecular Dynamics",
-    "GenMD",
-    "Markov State Models",
-    "AI for Science"
-  ],
-  "description": "Simon Olsson is an Associate Professor at Chalmers University of Technology and head of the AIMLeNS lab. He develops machine learning methods for molecular simulation and generative AI for drug and antibody design, with work published in Science, PNAS, and NeurIPS. He is a pioneer of Generative Molecular Dynamics, including methods such as Boltzmann Generators and Implicit Transfer Operators. Simon is a recipient of an ERC Consolidator Grant, and the ICTP-IBM Brahmagupta AI Prize 2025. Simon is a WASP Fellow and ELLIS Member. He was selected as part of the inaugural cohort of the Chalmers Academic Excellence Program. Simon is also a founder of the Chalmers AI for Science seminar series.",
-  "sameAs": [
-    "https://orcid.org/0000-0002-3927-7897",
-    "https://scholar.google.com/citations?user=EJMhxFIAAAAJ",
-    "https://www.chalmers.se/en/persons/simonols"
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": "https://psolsson.github.io/#simon-olsson",
+      "name": "Simon Olsson",
+      "givenName": "Simon",
+      "familyName": "Olsson",
+      "jobTitle": "Associate Professor",
+      "url": "https://psolsson.github.io",
+      "affiliation": {
+        "@type": "CollegeOrUniversity",
+        "name": "Chalmers University of Technology",
+        "url": "https://www.chalmers.se"
+      },
+      "worksFor": { "@id": "https://psolsson.github.io/#aimlens" },
+      "knowsAbout": [
+        "Machine Learning for Molecular Simulation",
+        "Generative AI for Drug Design",
+        "Boltzmann Generators",
+        "Implicit Transfer Operators",
+        "Generative Molecular Dynamics",
+        "GenMD",
+        "Markov State Models",
+        "AI for Science"
+      ],
+      "description": "Simon Olsson is an Associate Professor at Chalmers University of Technology and head of the AIMLeNS lab. He develops machine learning methods for molecular simulation and generative AI for drug and antibody design, with work published in Science, PNAS, and NeurIPS. He is a pioneer of Generative Molecular Dynamics, including methods such as Boltzmann Generators and Implicit Transfer Operators. Simon is a recipient of an ERC Consolidator Grant, and the ICTP-IBM Brahmagupta AI Prize 2025. Simon is a WASP Fellow and ELLIS Member. He was selected as part of the inaugural cohort of the Chalmers Academic Excellence Program. Simon is also a founder of the Chalmers AI for Science seminar series.",
+      "sameAs": [
+        "https://orcid.org/0000-0002-3927-7897",
+        "https://scholar.google.com/citations?user=EJMhxFIAAAAJ",
+        "https://www.chalmers.se/en/persons/simonols",
+        "https://github.com/psolsson",
+        "https://x.com/smnlssn"
+      ]
+    },
+    {
+      "@type": "ResearchOrganization",
+      "@id": "https://psolsson.github.io/#aimlens",
+      "name": "AIMLeNS — AI and Machine Learning in the Natural Sciences",
+      "alternateName": ["AIMLeNS", "AIMLeNS lab", "Olsson Group", "Simon Olsson Lab"],
+      "url": "https://psolsson.github.io",
+      "logo": "https://psolsson.github.io/assets/img/group2025.jpg",
+      "image": "https://psolsson.github.io/assets/img/group2025.jpg",
+      "description": "AIMLeNS is the AI and Machine Learning in the Natural Sciences research group at the Data Science and AI division of the Department of Computer Science and Engineering, Chalmers University of Technology. The group develops machine learning methods for molecular simulation, generative AI for inverse molecular design, and AI surrogates that bridge to experimentally observable time-scales.",
+      "parentOrganization": {
+        "@type": "CollegeOrUniversity",
+        "name": "Chalmers University of Technology",
+        "url": "https://www.chalmers.se",
+        "department": {
+          "@type": "EducationalOrganization",
+          "name": "Department of Computer Science and Engineering, Data Science and AI division"
+        },
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Gothenburg",
+          "addressCountry": "SE"
+        }
+      },
+      "member": { "@id": "https://psolsson.github.io/#simon-olsson" },
+      "knowsAbout": [
+        "AI for molecular simulation",
+        "Generative AI for molecular design",
+        "Drug discovery",
+        "Antibody design",
+        "Vaccine design",
+        "Materials design",
+        "Boltzmann generators",
+        "Flow matching for molecular dynamics",
+        "Implicit transfer operators"
+      ],
+      "funder": [
+        { "@type": "Organization", "name": "Knut and Alice Wallenberg Foundation", "url": "https://kaw.wallenberg.org/en" },
+        { "@type": "Organization", "name": "Wallenberg AI, Autonomous Systems and Software Program (WASP)", "url": "https://wasp-sweden.org/" },
+        { "@type": "Organization", "name": "Data-Driven Life Science (DDLS)", "url": "https://www.scilifelab.se/data-driven/" },
+        { "@type": "Organization", "name": "Wallenberg Centre for Quantum Technology (WACQT)", "url": "https://www.chalmers.se/en/centres/wacqt/" },
+        { "@type": "Organization", "name": "AstraZeneca AB", "url": "https://www.astrazeneca.com/" }
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://psolsson.github.io/#website",
+      "url": "https://psolsson.github.io",
+      "name": "AIMLeNS — AI and Machine Learning in the Natural Sciences",
+      "publisher": { "@id": "https://psolsson.github.io/#aimlens" },
+      "about": { "@id": "https://psolsson.github.io/#aimlens" }
+    }
   ]
 }
 </script>
@@ -45,12 +99,21 @@
 
 <!-- Open Graph -->
 {% if site.serve_og_meta %}
-<meta property="og:site_name" content="{{ site.description }}" />
-<meta property="og:type" content="object" />
-<meta property="og:title" content="{{ site.name }}" />
+<meta property="og:site_name" content="{{ site.title }}" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="{% if page.url == '/' %}{{ site.title }}{% else %}{{ page.title }} | {{ site.title }}{% endif %}" />
 <meta property="og:url" content="{{ page.url | prepend: site.baseurl | prepend: site.url }}" />
-<meta property="og:description" content="{{ page.title }}" />
-<meta property="og:image" content="{%- if page.og_image -%}{{ page.og_image }}{%- else -%}{{ site.og_image }}{%- endif -%}" />
+<meta property="og:description" content="{{ site.description | strip_newlines | strip }}" />
+<meta property="og:image" content="{%- if page.og_image -%}{{ page.og_image | prepend: site.url }}{%- else -%}{{ site.og_image | prepend: site.url }}{%- endif -%}" />
+<meta property="og:image:alt" content="AIMLeNS research group at Chalmers University of Technology, led by Simon Olsson" />
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@{{ site.twitter_username }}" />
+<meta name="twitter:creator" content="@{{ site.twitter_username }}" />
+<meta name="twitter:title" content="{% if page.url == '/' %}{{ site.title }}{% else %}{{ page.title }} | {{ site.title }}{% endif %}" />
+<meta name="twitter:description" content="{{ site.description | strip_newlines | strip }}" />
+<meta name="twitter:image" content="{%- if page.og_image -%}{{ page.og_image | prepend: site.url }}{%- else -%}{{ site.og_image | prepend: site.url }}{%- endif -%}" />
 {% endif %}
 
 <!-- Bootstrap & MDB -->

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,27 +2,89 @@
 layout: about
 title: about
 permalink: /
-description: "<meta name=\"description\" content=\"Research group at Chalmers University developing machine learning models to accelerate molecular simulations, molecular dynamics, vaccine design, drug design and materials design. Lead by Simon Olsson, pioneer in AI for Molecular Simulation.\">
-<p>The Artificial Intelligence and Machine Learning in the Natural Sciences (AIMLeNS), based at the Data Science and AI division of the Computer Science and Engineering department at Chalmers University of Technology, Gothenburg, Sweden. <br> In the AIMLeNS lab, we are broadly interested in the interface of AI and Machine learning to the Natural Sciences. </p>
-Currently, our main research areas are: 
+description: "<meta name=\"description\" content=\"AIMLeNS is the AI and Machine Learning in the Natural Sciences research group at Chalmers University of Technology, Gothenburg, led by Associate Professor Simon Olsson. We develop machine learning methods for molecular simulation, generative AI for drug, antibody and vaccine design, and AI-driven inverse molecular design.\">
+<p><strong>AIMLeNS</strong> (Artificial Intelligence and Machine Learning in the Natural Sciences) is a research group at the Data Science and AI division of the Department of Computer Science and Engineering, Chalmers University of Technology, Gothenburg, Sweden. The group is led by <a href=\"https://www.chalmers.se/en/persons/simonols\">Associate Professor Simon Olsson</a> and works at the interface of AI/machine learning and the natural sciences.</p>
+Our main research areas are: 
 <br> 
 <ol> 
-<li><b>AI and molecular simulations:</b> We are particularly interested in GenAI surrogates to bridge to experimentally observable time-scales.</li> 
-<li><b>Generative AI in inverse molecular design:</b> including design of small-molecule therapeutics, biologics, vaccines, and antibodies.</li> 
+<li><b>AI and molecular simulations:</b> We develop generative AI surrogates for molecular dynamics that bridge to experimentally observable time-scales, including Boltzmann generators, flow-matching methods, and implicit transfer operators.</li> 
+<li><b>Generative AI for inverse molecular design:</b> including design of small-molecule therapeutics, biologics, vaccines, and antibodies.</li> 
 </ol>
-<p>We're a tight-knit team of computer scientists, chemists, physicists, and mathematicians working collaboratively. Our focus is on developing practical methods that blend traditional disciplines with modern machine learning and AI technologies to effectively address large-scale problems.</p>
+<p>AIMLeNS is a tight-knit team of computer scientists, chemists, physicists, and mathematicians working collaboratively. Our focus is on developing practical methods that blend traditional disciplines with modern machine learning and AI technologies to effectively address large-scale problems in the natural sciences.</p>
 
 <p>
-<img src=\"https://psolsson.github.io/assets/img/group2025.jpg\" width=45%><br>
-AIMLeNS June 2025.
+<img src=\"https://psolsson.github.io/assets/img/group2025.jpg\" width=\"45%\" alt=\"AIMLeNS research group at Chalmers University of Technology, June 2025\"><br>
+AIMLeNS, June 2025.
 </p>
 <p>
-<img src=\"https://psolsson.github.io/assets/img/group_photo.jpg\" width=45%><br>
-AIMLeNS May 2024.
+<img src=\"https://psolsson.github.io/assets/img/group_photo.jpg\" width=\"45%\" alt=\"AIMLeNS research group at Chalmers University of Technology, May 2024\"><br>
+AIMLeNS, May 2024.
 </p>
 <br>
 
-We are currently funded generously by: <ul> <li><a href=\"https://kaw.wallenberg.org/en\">Knut and Alice Wallenberg foundation project grant</a></li> <li><a href=\"https://wasp-sweden.org/\">Wallenberg Autonomous Systems Program (WASP)</a></li> <li> <a href=\"https://www.scilifelab.se/data-driven/\"> Data-Driven Life Sciences (DDLS)</a></li> <li><a href=\"https://www.chalmers.se/en/centres/wacqt/\"> Wallenberg Centre for Quantum Technology (WACQT)</a></li> <li><a href=\"https://www.astrazeneca.com/\"> AstraZeneca AB</a></li> </ul>
+AIMLeNS is funded by:
+<ul>
+<li><a href=\"https://kaw.wallenberg.org/en\">Knut and Alice Wallenberg Foundation</a> project grant</li>
+<li><a href=\"https://wasp-sweden.org/\">Wallenberg AI, Autonomous Systems and Software Program (WASP)</a></li>
+<li><a href=\"https://www.scilifelab.se/data-driven/\">Data-Driven Life Science (DDLS)</a></li>
+<li><a href=\"https://www.chalmers.se/en/centres/wacqt/\">Wallenberg Centre for Quantum Technology (WACQT)</a></li>
+<li><a href=\"https://www.astrazeneca.com/\">AstraZeneca AB</a></li>
+</ul>
+
+<h2 id=\"frequently-asked-questions\">Frequently asked questions</h2>
+
+<h3 id=\"what-is-aimlens\">What is AIMLeNS?</h3>
+<p>AIMLeNS is the AI and Machine Learning in the Natural Sciences research group at Chalmers University of Technology in Gothenburg, Sweden. The lab is led by Associate Professor Simon Olsson and is part of the Data Science and AI division of the Department of Computer Science and Engineering.</p>
+
+<h3 id=\"who-is-simon-olsson\">Who is Simon Olsson?</h3>
+<p>Simon Olsson is an Associate Professor at Chalmers University of Technology and the head of the AIMLeNS lab. He works on machine learning for molecular simulation and generative AI for molecular design, and is known for contributions to Boltzmann generators, implicit transfer operators, and generative molecular dynamics. He is a WASP Fellow, ELLIS Member, recipient of an ERC Consolidator Grant, and the inaugural recipient of the ICTP-IBM Brahmagupta AI Prize.</p>
+
+<h3 id=\"what-does-the-lab-work-on\">What does the AIMLeNS lab work on?</h3>
+<p>AIMLeNS develops machine-learning methods for two main problems: (1) generative AI surrogates for molecular dynamics that bridge femtosecond simulations to experimentally observable time-scales, and (2) inverse molecular design of small-molecule therapeutics, biologics, vaccines, and antibodies.</p>
+
+<h3 id=\"how-do-i-join-the-lab\">How do I apply to join the AIMLeNS lab?</h3>
+<p>Open PhD, postdoc, and master-thesis positions are announced on the <a href=\"https://psolsson.github.io/team\">team page</a> and on Chalmers' official job portal. For research collaborations or other inquiries, contact Simon Olsson at <code>simonols [at] chalmers [dot] se</code>.</p>
+
+<script type=\"application/ld+json\">
+{
+  \"@context\": \"https://schema.org\",
+  \"@type\": \"FAQPage\",
+  \"mainEntity\": [
+    {
+      \"@type\": \"Question\",
+      \"name\": \"What is AIMLeNS?\",
+      \"acceptedAnswer\": {
+        \"@type\": \"Answer\",
+        \"text\": \"AIMLeNS is the AI and Machine Learning in the Natural Sciences research group at Chalmers University of Technology in Gothenburg, Sweden. The lab is led by Associate Professor Simon Olsson and is part of the Data Science and AI division of the Department of Computer Science and Engineering.\"
+      }
+    },
+    {
+      \"@type\": \"Question\",
+      \"name\": \"Who is Simon Olsson?\",
+      \"acceptedAnswer\": {
+        \"@type\": \"Answer\",
+        \"text\": \"Simon Olsson is an Associate Professor at Chalmers University of Technology and head of the AIMLeNS lab. He works on machine learning for molecular simulation and generative AI for molecular design, and is known for contributions to Boltzmann generators, implicit transfer operators, and generative molecular dynamics. He is a WASP Fellow, ELLIS Member, recipient of an ERC Consolidator Grant, and inaugural recipient of the ICTP-IBM Brahmagupta AI Prize.\"
+      }
+    },
+    {
+      \"@type\": \"Question\",
+      \"name\": \"What does the AIMLeNS lab work on?\",
+      \"acceptedAnswer\": {
+        \"@type\": \"Answer\",
+        \"text\": \"AIMLeNS develops machine-learning methods for two main problems: generative AI surrogates for molecular dynamics that bridge femtosecond simulations to experimentally observable time-scales, and inverse molecular design of small-molecule therapeutics, biologics, vaccines, and antibodies.\"
+      }
+    },
+    {
+      \"@type\": \"Question\",
+      \"name\": \"How do I apply to join the AIMLeNS lab?\",
+      \"acceptedAnswer\": {
+        \"@type\": \"Answer\",
+        \"text\": \"Open PhD, postdoc, and master-thesis positions are announced on the team page and on Chalmers' official job portal. For research collaborations or other inquiries, contact Simon Olsson at simonols@chalmers.se.\"
+      }
+    }
+  ]
+}
+</script>
 "
 
 #profile:
@@ -37,5 +99,4 @@ news: false  # includes a list of news items
 selected_papers: false # includes a list of papers marked as "selected={true}"
 social: false  # includes social icons at the bottom of the page
 ---
-
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,65 @@
+---
+layout: none
+permalink: /robots.txt
+---
+# Allow all standard search engine crawlers.
+User-agent: *
+Allow: /
+
+# Explicit allow for AI / LLM crawlers used by major assistants and search engines.
+# Listed individually so this is robust to changes in default behaviour.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: MistralAI-User
+Allow: /
+
+Sitemap: https://psolsson.github.io/sitemap.xml


### PR DESCRIPTION
Improves discoverability across traditional search and AI assistants (ChatGPT, Claude, Perplexity, Google AI Overviews).

Schema.org / JSON-LD
- Wrap existing Person schema in @graph and add ResearchOrganization for AIMLeNS, linked to Person via member/worksFor and to Chalmers via parentOrganization (with department and address).
- Add WebSite entity referencing the organization as publisher.
- Add FAQPage JSON-LD on the homepage covering the four most common questions an LLM would be asked about the group.

OpenGraph / Twitter
- Enable serve_og_meta (was off) and set a default og_image.
- Fix two correctness bugs in the existing OG block: og:site_name was set to the description, og:description to the page title. These are now mapped to the right fields.
- Add summary_large_image Twitter Card tags using @smnlssn.

Homepage copy
- Rewrite opening so it leads with the entity (AIMLeNS) and names the lead investigator + institution in the first sentence — gives LLMs a clean entity anchor to cluster.
- Fix 'Lead by Simon Olsson' -> 'Led by ...' typo (also in config).
- Add descriptive alt text to both group photos.
- Add a Frequently Asked Questions section matching the FAQPage schema.

Site config
- Replace the keyword-stuffed footer ('AI4Science, AI for Science, ...') with a natural-language description.
- Set the canonical site url so canonical/OG/sitemap tags are correct.
- Enable last_updated footer stamp as a freshness signal.
- Set site.title to lead with 'AIMLeNS'.

Discovery
- Add robots.txt that explicitly allows GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, Bingbot, CCBot, Meta-ExternalAgent, Amazonbot, DuckAssistBot, MistralAI-User, and points to the sitemap.
- Add jekyll-sitemap plugin (whitelisted by GitHub Pages) to auto-generate /sitemap.xml on every build.